### PR TITLE
Add whitelist to ValidationPipe — unknown body properties currently reach the Dynamoose write

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,5 @@
 // @ts-check
+import nestjsSecurity from 'eslint-plugin-nestjs-security';
 import eslint from '@eslint/js';
 import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
 import globals from 'globals';
@@ -26,7 +27,23 @@ export default tseslint.config(
     },
   },
   {
+    plugins: { 'nestjs-security': nestjsSecurity },
     rules: {
+      // Catches the missing `whitelist: true` this PR fixes, so it cannot come
+      // back: without it, properties absent from the DTO survive validation and
+      // reach the Dynamoose write.
+      'nestjs-security/require-validation-pipe-whitelist': 'error',
+
+      // Runtime risks that are already absent from this template today — kept
+      // that way for every project generated from it.
+      'nestjs-security/no-missing-validation-pipe': 'error',
+      'nestjs-security/require-throttler': 'warn',
+      'nestjs-security/no-exposed-private-fields': 'warn',
+      'nestjs-security/no-res-bypass-serialization': 'error',
+      'nestjs-security/no-unguarded-swagger': 'warn',
+      'nestjs-security/no-hybrid-app-config-loss': 'error',
+      'nestjs-security/no-unsafe-multer-filename': 'error',
+
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-floating-promises': 'off',
       '@typescript-eslint/no-unsafe-argument': 'off',

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "cross-env": "7.0.3",
     "eslint": "9.39.5",
     "eslint-config-prettier": "10.1.8",
+    "eslint-plugin-nestjs-security": "^2.3.0",
     "eslint-plugin-prettier": "5.5.6",
     "glob-promise": "6.0.7",
     "globals": "16.5.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ const bootstrapServer = async (): Promise<Handler> => {
     AppModule,
     new ExpressAdapter(expressApp),
   );
-  app.useGlobalPipes(new ValidationPipe({ forbidUnknownValues: true }));
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, forbidUnknownValues: true }));
   app.enableCors();
   await app.init();
   return serverlessExpress({

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.useGlobalPipes(new ValidationPipe({ forbidUnknownValues: true }));
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, forbidUnknownValues: true }));
   app.enableCors();
   await app.listen(3000);
 }


### PR DESCRIPTION
Hi — I'm Ofri Peretz. I maintain the [Interlace ESLint ecosystem](https://github.com/ofri-peretz/eslint). I found this while running one of my security plugins against NestJS starters; it looked like a genuine issue in the template rather than a lint opinion, so I'm sending the fix.

## The issue

Both entry points build the pipe without `whitelist`:

```ts
app.useGlobalPipes(new ValidationPipe({ forbidUnknownValues: true }));
```

`forbidUnknownValues` rejects a body with *no* validation metadata. It does **not** strip properties that are absent from the DTO — only `whitelist: true` does that. So extra properties pass validation and stay on the object.

They then reach the datastore, because the service spreads the whole input:

```ts
// notification.service.ts
create(input: CreateNotificationInput) {
  return this.model.create({ ...input, id: uuid.v4(), ... });
}

update(key: NotificationKey, input: UpdateNotificationInput) {
  return this.model.update(key, input);   // passed straight through
}
```

**The update path shows the impact most clearly.** `UpdateNotificationInput` declares exactly one field, constrained to a single value:

```ts
export class UpdateNotificationInput {
  @IsIn([NotificationStatus.Deleted])
  @IsEnum(NotificationStatus)
  status: NotificationStatus;
}
```

The intent is unmistakable — the only permitted update is a soft-delete. But today:

```bash
curl -X PATCH http://localhost:3000/notification/<id> \
  -H 'content-type: application/json' \
  -d '{"status":"Deleted","content":"attacker supplied","userId":"someone-else"}'
```

`status` validates, and `content` and `userId` ride along into `model.update`. Fields the API deliberately does not expose for update get rewritten. `create` is affected too, though `id`, `status` and `createAt` are overwritten after the spread, so those three are safe there.

## The fix

Two words, both entry points:

```diff
-app.useGlobalPipes(new ValidationPipe({ forbidUnknownValues: true }));
+app.useGlobalPipes(new ValidationPipe({ whitelist: true, forbidUnknownValues: true }));
```

This is what the [NestJS validation docs](https://docs.nestjs.com/techniques/validation#stripping-properties) recommend, and it needs no other change — every existing DTO field keeps working.

## Why it matters for this repo specifically

It's a starter. Every project generated from it inherits the pipe configuration, and a mass-assignment path in a template propagates far past this repository.

## The lint rule, optional

I also wired up `eslint-plugin-nestjs-security` so the fix can't silently regress, plus seven rules **this template already passes today** — they're a regression lock, not a to-do list. `npm run lint` stays green on this PR.

I deliberately left two rules out: `require-guards` (5 findings on `notification.controller.ts` — those endpoints look intentionally public in a starter, and that's your architectural call, not mine) and `no-permissive-cors` (the bare `enableCors()` looks deliberate for local development).

**Happy to split this** — if you'd rather take just the two-word fix and skip the lint config entirely, say so and I'll drop the second commit. The fix is the part that matters.